### PR TITLE
do not re-permit manually permitted params

### DIFF
--- a/lib/protector/adapters/active_record/strong_parameters.rb
+++ b/lib/protector/adapters/active_record/strong_parameters.rb
@@ -2,6 +2,7 @@ module Protector
   module ActiveRecord
     module StrongParameters
       def self.sanitize!(args, is_new, meta)
+        return if args[0].permitted?
         if is_new
           args[0] = args[0].permit(*meta.access[:create].keys) if meta.access.include? :create
         else


### PR DESCRIPTION
Fixes https://github.com/inossidabile/protector/issues/30
Permitting by attributes list doesn't work in general case when attribute isn't a scalar.
