### PR TITLE
Support arrays of actions in can statements

### DIFF
--- a/lib/protector/dsl.rb
+++ b/lib/protector/dsl.rb
@@ -102,23 +102,28 @@ module Protector
         #     # Can create f1 field with value equal to 'olo'
         #     can :create, f1: lambda{|x| x == 'olo'}
         #   end
-        def can(action, *fields)
-          action = deprecate_actions(action)
+        def can(actions, *fields)
+          Array.wrap(actions).each do |action|
+            action = deprecate_actions(action)
 
-          return @destroyable = true if action == :destroy
+            if action == :destroy
+              @destroyable = true
+              next
+            end
 
-          @access[action] = {} unless @access[action]
+            @access[action] = {} unless @access[action]
 
-          if fields.length == 0
-            @fields.each { |f| @access[action][f.to_s] = nil }
-          else
-            fields.each do |a|
-              if a.is_a?(Array)
-                a.each { |f| @access[action][f.to_s] = nil }
-              elsif a.is_a?(Hash)
-                @access[action].merge!(a.stringify_keys)
-              else
-                @access[action][a.to_s] = nil
+            if fields.length == 0
+              @fields.each { |f| @access[action][f.to_s] = nil }
+            else
+              fields.each do |a|
+                if a.is_a?(Array)
+                  a.each { |f| @access[action][f.to_s] = nil }
+                elsif a.is_a?(Hash)
+                  @access[action].merge!(a.stringify_keys)
+                else
+                  @access[action][a.to_s] = nil
+                end
               end
             end
           end


### PR DESCRIPTION
I find myself wanting to define a lot of permissions on both create and update (if a user can create a record with a given field, they most likely are also allowed to update that field.  This isn't too bad when it's just a few fields, but I have a complex model that requires the following statements:

``` ruby
            can :create, :name, :photo_file_name,
              :photo_content_type, :photo_file_size, :photo_updated_at, :photo,
              :photo_original_w, :photo_original_h, :photo_box_w, :photo_crop_x,
              :photo_crop_y, :photo_crop_w, :photo_crop_h, :photo_aspect
            can :update, :name, :photo_file_name,
              :photo_content_type, :photo_file_size, :photo_updated_at, :photo,
              :photo_original_w, :photo_original_h, :photo_box_w, :photo_crop_x,
              :photo_crop_y, :photo_crop_w, :photo_crop_h, :photo_aspect
```

Not only is this very verbose, it's a problem for maintenance as the field list changes.  

I've modified the `can` statement to optionally take an array of actions allowing the previous examples to be completed in one command.  

``` ruby
            can [:create, :update], :name, :photo_file_name,
              :photo_content_type, :photo_file_size, :photo_updated_at, :photo,
              :photo_original_w, :photo_original_h, :photo_box_w, :photo_crop_x,
              :photo_crop_y, :photo_crop_w, :photo_crop_h, :photo_aspect
```