### PR TITLE
Support reading multiple attributes at a time using an array as the key

### DIFF
--- a/lib/protector/dsl.rb
+++ b/lib/protector/dsl.rb
@@ -159,7 +159,7 @@ module Protector
 
         # Checks whether given field of a model is readable in context of current subject
         def readable?(field)
-          @access[:read] && @access[:read].key?(field.to_s)
+          Array.wrap(field).all? { |f| @access[:read] && @access[:read].key?(f.to_s) }
         end
 
         # Checks whether you can create a model with given field in context of current subject


### PR DESCRIPTION
I'm not sure if this is something supported directly by Active Record or something that is added by the Composite Primary Keys gem that we use but it is possible to get multiple fields out of an active record at one time using the `[]` operator.  Composite Primary Keys (CPK) uses this to get multi-field keys for associations.  

For example CPK, grabs multiple fields from my user object like this:

``` ruby
user[[:client_id, :source_id]]
```

Even though both of those fields were allowed in Protector, the read was returning `null` because it was looking for the array as a single field.  

This patch allows array based read permission checks and only allows them if all of the fields are authorized.  