### PR TITLE
Allow arrays of values in strong params

### DIFF
--- a/lib/protector/adapters/active_record/strong_parameters.rb
+++ b/lib/protector/adapters/active_record/strong_parameters.rb
@@ -5,9 +5,22 @@ module Protector
         def self.sanitize!(args, is_new, meta)
           return if args[0].permitted?
           if is_new
-            args[0] = args[0].permit(*meta.access[:create].keys) if meta.access.include? :create
+            if meta.access.include? :create
+              args[0] = args[0].permit(*mapped_permissions(meta.access[:create]))
+            end
           else
-            args[0] = args[0].permit(*meta.access[:update].keys) if meta.access.include? :update
+            if meta.access.include? :update
+              args[0] = args[0].permit(*mapped_permissions(meta.access[:update]))
+            end
+          end
+        end
+
+        # Permit nested array of scalar values.
+        #
+        # can :create, :name, {nicknames: []}, :address
+        def self.mapped_permissions(access)
+          access.map do |key, value|
+            value.nil? ? key : { key => value }
           end
         end
 


### PR DESCRIPTION
Allow whitelisting arrays of values in strong params.  Let's you write `can` statements like this:

``` ruby
can :update, selected_features: []
```