### PR TITLE
Fix adequate record modified relation warnings

### DIFF
--- a/lib/protector/adapters/active_record/relation.rb
+++ b/lib/protector/adapters/active_record/relation.rb
@@ -139,6 +139,7 @@ module Protector
 
           # Preserve associations from internal loading. We are going to handle that
           # ourselves respecting security scopes FTW!
+          relation = relation.clone
           associations, relation.preload_values = relation.preload_values, []
 
           @records = relation.send(:exec_queries).each { |record| record.restrict!(subject) }
@@ -179,6 +180,7 @@ module Protector
               end
             end
           else
+            relation = relation.clone
             relation.preload_values += includes_values
             relation.includes_values = []
           end


### PR DESCRIPTION
Add a couple relation.clone statements to get around the new adequate record modified relation warnings.  I'm not sure if this is the right way to do it, but at least its stops my tests from spewing warnings all over the place. 