### PR TITLE
Whitelist params for build

### DIFF
--- a/lib/protector/adapters/active_record/association.rb
+++ b/lib/protector/adapters/active_record/association.rb
@@ -29,7 +29,19 @@ module Protector
         # Forwards protection subject to the new instance
         def build_record_with_protector(*args)
           return build_record_without_protector(*args) unless protector_subject?
+
+          protector_permit_strong_params(args)
           build_record_without_protector(*args).restrict!(protector_subject)
+        end
+
+        private
+
+        def protector_meta(subject=protector_subject)
+          klass.protector_meta.evaluate(subject)
+        end
+
+        def protector_permit_strong_params(args)
+          Protector::ActiveRecord::Adapters::StrongParameters.sanitize! args, true, protector_meta
         end
       end
     end

--- a/lib/protector/adapters/active_record/relation.rb
+++ b/lib/protector/adapters/active_record/relation.rb
@@ -231,9 +231,7 @@ module Protector
 
         def protector_permit_strong_params(args)
           # strong_parameters integration
-          if Protector.config.strong_parameters? && args.first.respond_to?(:permit)
-            Protector::ActiveRecord::Adapters::StrongParameters.sanitize! args, true, protector_meta
-          end
+          Protector::ActiveRecord::Adapters::StrongParameters.sanitize! args, true, protector_meta
         end
 
 

--- a/lib/protector/adapters/active_record/strong_parameters.rb
+++ b/lib/protector/adapters/active_record/strong_parameters.rb
@@ -3,6 +3,7 @@ module Protector
     module Adapters
       module StrongParameters
         def self.sanitize!(args, is_new, meta)
+          return unless Protector.config.strong_parameters? && args.first.respond_to?(:permit)
           return if args[0].permitted?
           if is_new
             args[0] = args[0].permit(*meta.access[:create].keys) if meta.access.include? :create
@@ -16,9 +17,7 @@ module Protector
           # We check only for updation here since the creation will be handled by relation
           # (see Protector::Adapters::ActiveRecord::Relation#new_with_protector and
           # Protector::Adapters::ActiveRecord::Relation#create_with_protector)
-          if Protector.config.strong_parameters? && args.first.respond_to?(:permit) \
-              && !new_record? && protector_subject?
-
+          if !new_record? && protector_subject?
             StrongParameters.sanitize! args, false, protector_meta
           end
 


### PR DESCRIPTION
Protector already handles whitelisting strong params for new create and update:

``` ruby
Model.new(params)
Model.create(params)
Model.first.update(params)
```

but it doesn't currently handle building off of an association:

``` ruby
associated = Model.first.associated_model.build(params)
```

This PR adds that capability. 
