### PR TITLE
Rails 5.2 support

### DIFF
--- a/lib/protector/adapters/active_record/association.rb
+++ b/lib/protector/adapters/active_record/association.rb
@@ -10,13 +10,15 @@ module Protector
 
           # AR 4 has renamed `scoped` to `scope`
           if method_defined?(:scope)
-            alias_method_chain :scope, :protector
+            alias_method :scope_without_protector, :scope
+            alias_method :scope, :scope_with_protector
           else
             alias_method 'scope_without_protector', 'scoped'
             alias_method 'scoped', 'scope_with_protector'
           end
 
-          alias_method_chain :build_record, :protector
+          alias_method :build_record_without_protector, :build_record
+          alias_method :build_record, :build_record_with_protector
         end
 
         # Wraps every association with current subject

--- a/lib/protector/adapters/active_record/preloader.rb
+++ b/lib/protector/adapters/active_record/preloader.rb
@@ -8,8 +8,9 @@ module Protector
         module Association extend ActiveSupport::Concern
           included do
             # AR 4 has renamed `scoped` to `scope`
-            if method_defined?(:scope)
-              alias_method_chain :scope, :protector
+            if method_defined?(:scope) || private_method_defined?(:scope)
+              alias_method :scope_without_protector, :scope
+              alias_method :scope, :scope_with_protector
             else
               alias_method 'scope_without_protector', 'scoped'
               alias_method 'scoped', 'scope_with_protector'

--- a/lib/protector/adapters/active_record/relation.rb
+++ b/lib/protector/adapters/active_record/relation.rb
@@ -8,10 +8,17 @@ module Protector
         included do
           include Protector::DSL::Base
 
-          alias_method_chain :exec_queries, :protector
-          alias_method_chain :new, :protector
-          alias_method_chain :create, :protector
-          alias_method_chain :create!, :protector
+          alias_method :exec_queries_without_protector, :exec_queries
+          alias_method :exec_queries, :exec_queries_with_protector
+
+          alias_method :new_without_protector, :new
+          alias_method :new, :new_with_protector
+
+          alias_method :create_without_protector, :create
+          alias_method :create, :create_with_protector
+
+          alias_method :create_without_protector!, :create!
+          alias_method :create!, :create_with_protector!
 
           # AR 3.2 workaround. Come on, guys... SQL parsing :(
           unless method_defined?(:references_values)

--- a/lib/protector/adapters/active_record/singular_association.rb
+++ b/lib/protector/adapters/active_record/singular_association.rb
@@ -6,7 +6,8 @@ module Protector
         extend ActiveSupport::Concern
 
         included do
-          alias_method_chain :reader, :protector
+          alias_method :reader_without_protector, :reader
+          alias_method :reader, :reader_with_protector
         end
 
         # Reader has to be explicitly overrided for cases when the

--- a/lib/protector/adapters/sequel/dataset.rb
+++ b/lib/protector/adapters/sequel/dataset.rb
@@ -27,7 +27,8 @@ module Protector
         included do |klass|
           include Protector::DSL::Base
 
-          alias_method_chain :each, :protector
+          alias_method :each_without_protector, :each
+          alias_method :each, :each_with_protector
         end
 
         def creatable?

--- a/lib/protector/adapters/sequel/eager_graph_loader.rb
+++ b/lib/protector/adapters/sequel/eager_graph_loader.rb
@@ -5,7 +5,8 @@ module Protector
       module EagerGraphLoader extend ActiveSupport::Concern
 
         included do
-          alias_method_chain :initialize, :protector
+          alias_method :initialize_without_protector, :initialize
+          alias_method :initialize, :initialize_with_protector
         end
 
         def initialize_with_protector(dataset)

--- a/lib/protector/version.rb
+++ b/lib/protector/version.rb
@@ -1,4 +1,4 @@
 module Protector
   # Gem version
-  VERSION = '0.7.7'
+  VERSION = '0.7.8'
 end


### PR DESCRIPTION
- replace alias_method_chain with alias_method
- fix the issue caused by `scope` becoming a private method